### PR TITLE
BUG-1 - Fix the missing comma in the title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <title>Hello RTP</title>
+    <title>Hello, RTP</title>
 </head>
 
 <body>


### PR DESCRIPTION
The title wasn't consistent with the body text.  Added a comma to the title.